### PR TITLE
MeterianBot has fixed some issues in your codebase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.meterian.qa.samples</groupId>
@@ -39,7 +37,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.1.11</version>
+            <version>1.2.3</version>
         </dependency>
 
         <!-- has major version 4.1.12 (inentionally NOT in test scope) -->
@@ -53,7 +51,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.15</version>
+            <version>8.0.22</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Hey! We’ve found issues with some of the libraries you are using in your project, **MeterianBot** managed to fix some of them for you but unfortunately not all of them. They just need your approval.

The security score of your project is **90**, the stability score **100** and the licensing score **0**.
You can have a more detailed look at the report [here](https://qa.meterian.com/projects/?pid=51e2a274-6186-447b-a48f-935240cdcb3d&branch=master&mode=eli).

## Fixes
- We’ve updated **ch.qos.logback:logback-core** **1.1.11** to **1.2.3** minor release, because of **[CVE-2017-5929](https://nvd.nist.gov/vuln/details/CVE-2017-5929)**.

&nbsp;&nbsp;&nbsp;&nbsp;Threat severity: **HIGH** &nbsp;&nbsp;&nbsp;&nbsp; CVSS score: **7.5**

> QOS.ch Logback before 1.2.0 has a serialization vulnerability affecting the SocketServer and ServerSocketReceiver components.

---

- We’ve updated **mysql:mysql-connector-java** **8.0.15** to **8.0.22** patch release, because of **[CVE-2019-2692](https://nvd.nist.gov/vuln/details/CVE-2019-2692)**.

&nbsp;&nbsp;&nbsp;&nbsp;Threat severity: **MEDIUM** &nbsp;&nbsp;&nbsp;&nbsp; CVSS score: **6.3**

>Vulnerability in the MySQL Connectors component of Oracle MySQL (subcomponent: Connector/J). Supported versions that are affected are 8.0.15 and prior. Difficult to exploit vulnerability allows high privileged attacker with logon to the infrastructure where MySQL Connectors executes to compromise MySQL Connectors. Successful attacks require human interaction from a person other than the attacker. Successful attacks of this vulnerability can result in takeover of MySQL Connectors. CVSS 3.0 Base Score 6.3 (Confidentiality, Integrity and Availability impacts). CVSS Vector: (CVSS:3.0/AV:L/AC:H/PR:H/UI:R/S:U/C:H/I:H/A:H). 

---

## Issues
- **junit:junit** **3.8.2** is affected by a security vulnerability.

&nbsp;&nbsp;&nbsp;&nbsp;Threat severity: **LOW** &nbsp;&nbsp;&nbsp;&nbsp; CVSS score: **2**

>The JUnit4 test rule TemporaryFolder contains a local information disclosure vulnerability.

&nbsp;&nbsp;&nbsp;&nbsp;junit:junit 4.13.1 major release is the next safe version.

---

## Licenses
- 4 libraries declare a license which violates the company policies.

Have a look at the [report](https://qa.meterian.com/projects/?pid=51e2a274-6186-447b-a48f-935240cdcb3d&branch=master&mode=eli) for more details and find out [how a licenses can impact your business](https://blog.meterian.com/2019/05/22/how-the-wrong-license-can-harm-your-business/).